### PR TITLE
feat: add RocksDB backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,26 @@ jobs:
       - name: Test
         run: ctest --test-dir build-tests --output-on-failure
 
+  test-rocksdb:
+    name: RocksDB Backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtest-dev cmake librocksdb-dev
+
+      - name: Configure
+        run: cmake -S tests -B build-tests-rocksdb -DWITH_ROCKSDB=ON
+
+      - name: Build
+        run: cmake --build build-tests-rocksdb
+
+      - name: Test
+        run: ctest --test-dir build-tests-rocksdb --output-on-failure
+
   build-plugin:
     name: Qt Plugin Build
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,18 @@ if(NOT "${LOGOS_CORE_ROOT}" STREQUAL "")
     )
 endif()
 
+# ── RocksDB (optional) ────────────────────────────────────────────────────────
+option(WITH_ROCKSDB "Build RocksDB backend" OFF)
+if(WITH_ROCKSDB)
+    find_package(RocksDB QUIET)
+    if(NOT RocksDB_FOUND)
+        find_package(PkgConfig)
+        if(PkgConfig_FOUND)
+            pkg_check_modules(ROCKSDB IMPORTED_TARGET rocksdb)
+        endif()
+    endif()
+endif()
+
 # ── Plugin target ─────────────────────────────────────────────────────────────
 qt_add_plugin(kv_module CLASS_NAME KvPlugin)
 
@@ -33,6 +45,10 @@ target_sources(kv_module PRIVATE
     src/backends/MemoryBackend.cpp
     src/backends/FileBackend.cpp
 )
+
+if(WITH_ROCKSDB AND (RocksDB_FOUND OR ROCKSDB_FOUND))
+    target_sources(kv_module PRIVATE src/backends/RocksDbBackend.cpp)
+endif()
 
 set_property(TARGET kv_module PROPERTY PUBLIC_HEADER
     src/i_kv_module.h
@@ -48,6 +64,15 @@ target_link_libraries(kv_module PRIVATE
 if(NOT "${LOGOS_CORE_ROOT}" STREQUAL "")
     target_link_libraries(kv_module PRIVATE logos_cpp_sdk logos_core)
     target_compile_definitions(kv_module PRIVATE LOGOS_CORE_AVAILABLE)
+endif()
+
+if(WITH_ROCKSDB)
+    if(RocksDB_FOUND)
+        target_link_libraries(kv_module PRIVATE RocksDB::rocksdb)
+    elseif(ROCKSDB_FOUND)
+        target_link_libraries(kv_module PRIVATE PkgConfig::ROCKSDB)
+    endif()
+    target_compile_definitions(kv_module PRIVATE HAVE_ROCKSDB)
 endif()
 
 # ── Compile definitions ──────────────────────────────────────────────────────

--- a/src/backends/RocksDbBackend.cpp
+++ b/src/backends/RocksDbBackend.cpp
@@ -1,0 +1,85 @@
+#include "RocksDbBackend.h"
+
+#include <rocksdb/db.h>
+#include <rocksdb/iterator.h>
+#include <rocksdb/write_batch.h>
+#include <stdexcept>
+
+RocksDbBackend::RocksDbBackend(std::filesystem::path db_path)
+    : db_path_(std::move(db_path)) {
+    rocksdb::Options options;
+    options.create_if_missing = true;
+    auto status = rocksdb::DB::Open(options, db_path_.string(), &db_);
+    if (!status.ok()) {
+        throw std::runtime_error("Failed to open RocksDB at " +
+                                 db_path_.string() + ": " +
+                                 status.ToString());
+    }
+}
+
+RocksDbBackend::~RocksDbBackend() {
+    delete db_;
+}
+
+void RocksDbBackend::set(const std::string &key, const std::string &value) {
+    std::lock_guard lock(write_mutex_);
+    auto status = db_->Put(rocksdb::WriteOptions(), key, value);
+    if (!status.ok()) {
+        throw std::runtime_error("RocksDB Put failed: " + status.ToString());
+    }
+}
+
+std::optional<std::string> RocksDbBackend::get(const std::string &key) {
+    std::string value;
+    auto status = db_->Get(rocksdb::ReadOptions(), key, &value);
+    if (status.IsNotFound())
+        return std::nullopt;
+    if (!status.ok()) {
+        throw std::runtime_error("RocksDB Get failed: " + status.ToString());
+    }
+    return value;
+}
+
+void RocksDbBackend::remove(const std::string &key) {
+    std::lock_guard lock(write_mutex_);
+    auto status = db_->Delete(rocksdb::WriteOptions(), key);
+    if (!status.ok()) {
+        throw std::runtime_error("RocksDB Delete failed: " + status.ToString());
+    }
+}
+
+std::vector<std::string> RocksDbBackend::list(const std::string &prefix) {
+    std::vector<std::string> result;
+    std::unique_ptr<rocksdb::Iterator> it(
+        db_->NewIterator(rocksdb::ReadOptions()));
+
+    if (prefix.empty()) {
+        for (it->SeekToFirst(); it->Valid(); it->Next()) {
+            result.emplace_back(it->key().data(), it->key().size());
+        }
+    } else {
+        for (it->Seek(prefix); it->Valid(); it->Next()) {
+            auto key = it->key();
+            if (key.size() < prefix.size() ||
+                key.ToString().compare(0, prefix.size(), prefix) != 0) {
+                break;
+            }
+            result.emplace_back(key.data(), key.size());
+        }
+    }
+    return result;
+}
+
+void RocksDbBackend::clear() {
+    std::lock_guard lock(write_mutex_);
+    rocksdb::WriteBatch batch;
+    std::unique_ptr<rocksdb::Iterator> it(
+        db_->NewIterator(rocksdb::ReadOptions()));
+    for (it->SeekToFirst(); it->Valid(); it->Next()) {
+        batch.Delete(it->key());
+    }
+    auto status = db_->Write(rocksdb::WriteOptions(), &batch);
+    if (!status.ok()) {
+        throw std::runtime_error("RocksDB clear failed: " + status.ToString());
+    }
+}

--- a/src/backends/RocksDbBackend.h
+++ b/src/backends/RocksDbBackend.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "KvBackend.h"
+
+#include <filesystem>
+#include <memory>
+#include <mutex>
+
+namespace rocksdb {
+class DB;
+}
+
+class RocksDbBackend : public KvBackend {
+public:
+    explicit RocksDbBackend(std::filesystem::path db_path);
+    ~RocksDbBackend() override;
+
+    void set(const std::string &key, const std::string &value) override;
+    std::optional<std::string> get(const std::string &key) override;
+    void remove(const std::string &key) override;
+    std::vector<std::string> list(const std::string &prefix) override;
+    void clear() override;
+
+private:
+    std::filesystem::path db_path_;
+    rocksdb::DB *db_ = nullptr;
+    std::mutex write_mutex_;
+};

--- a/tests/BackendConformanceTest.cpp
+++ b/tests/BackendConformanceTest.cpp
@@ -3,6 +3,9 @@
 #include "backends/KvBackend.h"
 #include "backends/MemoryBackend.h"
 #include "backends/FileBackend.h"
+#ifdef HAVE_ROCKSDB
+#include "backends/RocksDbBackend.h"
+#endif
 
 #include <algorithm>
 #include <atomic>
@@ -21,6 +24,12 @@ protected:
         if (GetParam() == "MemoryBackend") {
             return std::make_unique<MemoryBackend>();
         }
+#ifdef HAVE_ROCKSDB
+        if (GetParam() == "RocksDbBackend") {
+            auto dir = makeTempDir();
+            return std::make_unique<RocksDbBackend>(dir);
+        }
+#endif
         auto dir = makeTempDir();
         return std::make_unique<FileBackend>(dir);
     }
@@ -194,10 +203,18 @@ TEST_P(BackendConformanceTest, ConcurrentWrites) {
     }
 }
 
+static auto backendValues() {
+    std::vector<std::string> backends = {"MemoryBackend", "FileBackend"};
+#ifdef HAVE_ROCKSDB
+    backends.push_back("RocksDbBackend");
+#endif
+    return ::testing::ValuesIn(backends);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     Backends,
     BackendConformanceTest,
-    ::testing::Values("MemoryBackend", "FileBackend"),
+    backendValues(),
     [](const ::testing::TestParamInfo<std::string> &info) {
         return info.param;
     });

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,21 +12,53 @@ find_package(Threads REQUIRED)
 
 enable_testing()
 
-add_executable(backend_conformance_test
-    BackendConformanceTest.cpp
+set(BACKEND_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/backends/MemoryBackend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/backends/FileBackend.cpp
+)
+
+set(BACKEND_LIBS
+    GTest::GTest
+    GTest::Main
+    Threads::Threads
+)
+
+option(WITH_ROCKSDB "Build with RocksDB backend" OFF)
+if(WITH_ROCKSDB)
+    find_package(RocksDB QUIET)
+    if(NOT RocksDB_FOUND)
+        find_package(PkgConfig)
+        if(PkgConfig_FOUND)
+            pkg_check_modules(ROCKSDB IMPORTED_TARGET rocksdb)
+        endif()
+    endif()
+
+    if(RocksDB_FOUND OR ROCKSDB_FOUND)
+        list(APPEND BACKEND_SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/backends/RocksDbBackend.cpp
+        )
+    endif()
+endif()
+
+add_executable(backend_conformance_test
+    BackendConformanceTest.cpp
+    ${BACKEND_SOURCES}
 )
 
 target_include_directories(backend_conformance_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../src
 )
 
-target_link_libraries(backend_conformance_test
-    GTest::GTest
-    GTest::Main
-    Threads::Threads
-)
+target_link_libraries(backend_conformance_test ${BACKEND_LIBS})
+
+if(WITH_ROCKSDB)
+    if(RocksDB_FOUND)
+        target_link_libraries(backend_conformance_test RocksDB::rocksdb)
+    elseif(ROCKSDB_FOUND)
+        target_link_libraries(backend_conformance_test PkgConfig::ROCKSDB)
+    endif()
+    target_compile_definitions(backend_conformance_test PRIVATE HAVE_ROCKSDB)
+endif()
 
 include(GoogleTest)
 gtest_discover_tests(backend_conformance_test)


### PR DESCRIPTION
## Summary
- Adds `RocksDbBackend` implementing the `KvBackend` interface using RocksDB (`rocksdb::DB`)
- Gated behind `-DWITH_ROCKSDB=ON` CMake option with `HAVE_ROCKSDB` compile definition
- Conformance tests automatically include `RocksDbBackend` when built with RocksDB support
- CI job installs `librocksdb-dev` and runs all conformance tests against the RocksDB backend

## Test plan
- [ ] CI "RocksDB Backend" job passes (builds + conformance tests)
- [ ] CI "Conformance Tests" job still passes (RocksDB not linked, no regressions)
- [ ] CI "Qt Plugin Build" job still passes (optional dep doesn't break plugin)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)