### PR TITLE
feat: add SQLite backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,26 @@ jobs:
       - name: Test
         run: ctest --test-dir build-tests-rocksdb --output-on-failure
 
+  test-sqlite:
+    name: SQLite Backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtest-dev cmake libsqlite3-dev
+
+      - name: Configure
+        run: cmake -S tests -B build-tests-sqlite -DWITH_SQLITE=ON
+
+      - name: Build
+        run: cmake --build build-tests-sqlite
+
+      - name: Test
+        run: ctest --test-dir build-tests-sqlite --output-on-failure
+
   build-plugin:
     name: Qt Plugin Build
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,12 @@ if(WITH_ROCKSDB)
     endif()
 endif()
 
+# ── SQLite (optional) ─────────────────────────────────────────────────────────
+option(WITH_SQLITE "Build SQLite backend" OFF)
+if(WITH_SQLITE)
+    find_package(SQLite3 REQUIRED)
+endif()
+
 # ── Plugin target ─────────────────────────────────────────────────────────────
 qt_add_plugin(kv_module CLASS_NAME KvPlugin)
 
@@ -48,6 +54,10 @@ target_sources(kv_module PRIVATE
 
 if(WITH_ROCKSDB AND (RocksDB_FOUND OR ROCKSDB_FOUND))
     target_sources(kv_module PRIVATE src/backends/RocksDbBackend.cpp)
+endif()
+
+if(WITH_SQLITE)
+    target_sources(kv_module PRIVATE src/backends/SqliteBackend.cpp)
 endif()
 
 set_property(TARGET kv_module PROPERTY PUBLIC_HEADER
@@ -73,6 +83,11 @@ if(WITH_ROCKSDB)
         target_link_libraries(kv_module PRIVATE PkgConfig::ROCKSDB)
     endif()
     target_compile_definitions(kv_module PRIVATE HAVE_ROCKSDB)
+endif()
+
+if(WITH_SQLITE)
+    target_link_libraries(kv_module PRIVATE SQLite::SQLite3)
+    target_compile_definitions(kv_module PRIVATE HAVE_SQLITE)
 endif()
 
 # ── Compile definitions ──────────────────────────────────────────────────────

--- a/src/backends/SqliteBackend.cpp
+++ b/src/backends/SqliteBackend.cpp
@@ -1,0 +1,199 @@
+#include "SqliteBackend.h"
+
+#include <sqlite3.h>
+#include <stdexcept>
+
+SqliteBackend::SqliteBackend(std::filesystem::path db_path)
+    : db_path_(std::move(db_path)) {
+    int rc = sqlite3_open(db_path_.string().c_str(), &db_);
+    if (rc != SQLITE_OK) {
+        std::string err = sqlite3_errmsg(db_);
+        sqlite3_close(db_);
+        db_ = nullptr;
+        throw std::runtime_error("Failed to open SQLite DB at " +
+                                 db_path_.string() + ": " + err);
+    }
+
+    // Create table
+    char *errmsg = nullptr;
+    rc = sqlite3_exec(db_,
+        "CREATE TABLE IF NOT EXISTS kv ("
+        "key TEXT PRIMARY KEY, "
+        "value BLOB NOT NULL"
+        ");",
+        nullptr, nullptr, &errmsg);
+    if (rc != SQLITE_OK) {
+        std::string err = errmsg ? errmsg : "unknown error";
+        sqlite3_free(errmsg);
+        sqlite3_close(db_);
+        db_ = nullptr;
+        throw std::runtime_error("Failed to create kv table: " + err);
+    }
+
+    // Prepare statements
+    auto prepare = [&](const char *sql, sqlite3_stmt **stmt) {
+        rc = sqlite3_prepare_v2(db_, sql, -1, stmt, nullptr);
+        if (rc != SQLITE_OK) {
+            std::string err = sqlite3_errmsg(db_);
+            finalize();
+            sqlite3_close(db_);
+            db_ = nullptr;
+            throw std::runtime_error(
+                std::string("Failed to prepare statement: ") + err);
+        }
+    };
+
+    prepare("INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)", &stmt_set_);
+    prepare("SELECT value FROM kv WHERE key = ?", &stmt_get_);
+    prepare("DELETE FROM kv WHERE key = ?", &stmt_remove_);
+    prepare("DELETE FROM kv", &stmt_clear_);
+}
+
+SqliteBackend::~SqliteBackend() {
+    finalize();
+    if (db_) {
+        sqlite3_close(db_);
+    }
+}
+
+void SqliteBackend::finalize() {
+    auto fin = [](sqlite3_stmt *&s) {
+        if (s) {
+            sqlite3_finalize(s);
+            s = nullptr;
+        }
+    };
+    fin(stmt_set_);
+    fin(stmt_get_);
+    fin(stmt_remove_);
+    fin(stmt_clear_);
+}
+
+void SqliteBackend::set(const std::string &key, const std::string &value) {
+    std::lock_guard lock(mutex_);
+    sqlite3_reset(stmt_set_);
+    sqlite3_bind_text(stmt_set_, 1, key.data(), static_cast<int>(key.size()),
+                      SQLITE_STATIC);
+    sqlite3_bind_blob(stmt_set_, 2, value.data(), static_cast<int>(value.size()),
+                      SQLITE_STATIC);
+    int rc = sqlite3_step(stmt_set_);
+    if (rc != SQLITE_DONE) {
+        throw std::runtime_error(std::string("SQLite set failed: ") +
+                                 sqlite3_errmsg(db_));
+    }
+}
+
+std::optional<std::string> SqliteBackend::get(const std::string &key) {
+    std::lock_guard lock(mutex_);
+    sqlite3_reset(stmt_get_);
+    sqlite3_bind_text(stmt_get_, 1, key.data(), static_cast<int>(key.size()),
+                      SQLITE_STATIC);
+    int rc = sqlite3_step(stmt_get_);
+    if (rc == SQLITE_ROW) {
+        const void *blob = sqlite3_column_blob(stmt_get_, 0);
+        int len = sqlite3_column_bytes(stmt_get_, 0);
+        return std::string(static_cast<const char *>(blob),
+                           static_cast<size_t>(len));
+    }
+    if (rc == SQLITE_DONE) {
+        return std::nullopt;
+    }
+    throw std::runtime_error(std::string("SQLite get failed: ") +
+                             sqlite3_errmsg(db_));
+}
+
+void SqliteBackend::remove(const std::string &key) {
+    std::lock_guard lock(mutex_);
+    sqlite3_reset(stmt_remove_);
+    sqlite3_bind_text(stmt_remove_, 1, key.data(), static_cast<int>(key.size()),
+                      SQLITE_STATIC);
+    int rc = sqlite3_step(stmt_remove_);
+    if (rc != SQLITE_DONE) {
+        throw std::runtime_error(std::string("SQLite remove failed: ") +
+                                 sqlite3_errmsg(db_));
+    }
+}
+
+std::vector<std::string> SqliteBackend::list(const std::string &prefix) {
+    std::lock_guard lock(mutex_);
+    std::vector<std::string> result;
+
+    sqlite3_stmt *stmt = nullptr;
+    int rc;
+
+    if (prefix.empty()) {
+        rc = sqlite3_prepare_v2(db_, "SELECT key FROM kv ORDER BY key", -1,
+                                &stmt, nullptr);
+    } else {
+        // Use range comparison to avoid LIKE escaping issues:
+        // key >= prefix AND key < prefix_end
+        // where prefix_end is prefix with last byte incremented.
+        std::string upper = prefix;
+        // Increment the last byte to form the exclusive upper bound.
+        // Walk backwards to handle 0xFF overflow.
+        bool found = false;
+        for (auto it = upper.rbegin(); it != upper.rend(); ++it) {
+            if (static_cast<unsigned char>(*it) < 0xFF) {
+                ++(*it);
+                // Erase everything after this position
+                upper.erase(it.base(), upper.end());
+                found = true;
+                break;
+            }
+        }
+        if (found) {
+            rc = sqlite3_prepare_v2(
+                db_,
+                "SELECT key FROM kv WHERE key >= ? AND key < ? ORDER BY key",
+                -1, &stmt, nullptr);
+            if (rc == SQLITE_OK) {
+                sqlite3_bind_text(stmt, 1, prefix.data(),
+                                  static_cast<int>(prefix.size()),
+                                  SQLITE_STATIC);
+                sqlite3_bind_text(stmt, 2, upper.data(),
+                                  static_cast<int>(upper.size()),
+                                  SQLITE_STATIC);
+            }
+        } else {
+            // All bytes are 0xFF — match everything >= prefix
+            rc = sqlite3_prepare_v2(
+                db_, "SELECT key FROM kv WHERE key >= ? ORDER BY key", -1,
+                &stmt, nullptr);
+            if (rc == SQLITE_OK) {
+                sqlite3_bind_text(stmt, 1, prefix.data(),
+                                  static_cast<int>(prefix.size()),
+                                  SQLITE_STATIC);
+            }
+        }
+    }
+
+    if (rc != SQLITE_OK) {
+        throw std::runtime_error(std::string("SQLite list prepare failed: ") +
+                                 sqlite3_errmsg(db_));
+    }
+
+    while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+        const char *key =
+            reinterpret_cast<const char *>(sqlite3_column_text(stmt, 0));
+        int len = sqlite3_column_bytes(stmt, 0);
+        result.emplace_back(key, static_cast<size_t>(len));
+    }
+    sqlite3_finalize(stmt);
+
+    if (rc != SQLITE_DONE) {
+        throw std::runtime_error(std::string("SQLite list failed: ") +
+                                 sqlite3_errmsg(db_));
+    }
+
+    return result;
+}
+
+void SqliteBackend::clear() {
+    std::lock_guard lock(mutex_);
+    sqlite3_reset(stmt_clear_);
+    int rc = sqlite3_step(stmt_clear_);
+    if (rc != SQLITE_DONE) {
+        throw std::runtime_error(std::string("SQLite clear failed: ") +
+                                 sqlite3_errmsg(db_));
+    }
+}

--- a/src/backends/SqliteBackend.h
+++ b/src/backends/SqliteBackend.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "KvBackend.h"
+
+#include <filesystem>
+#include <mutex>
+
+struct sqlite3;
+struct sqlite3_stmt;
+
+class SqliteBackend : public KvBackend {
+public:
+    explicit SqliteBackend(std::filesystem::path db_path);
+    ~SqliteBackend() override;
+
+    void set(const std::string &key, const std::string &value) override;
+    std::optional<std::string> get(const std::string &key) override;
+    void remove(const std::string &key) override;
+    std::vector<std::string> list(const std::string &prefix) override;
+    void clear() override;
+
+private:
+    std::filesystem::path db_path_;
+    sqlite3 *db_ = nullptr;
+    sqlite3_stmt *stmt_set_ = nullptr;
+    sqlite3_stmt *stmt_get_ = nullptr;
+    sqlite3_stmt *stmt_remove_ = nullptr;
+    sqlite3_stmt *stmt_clear_ = nullptr;
+    std::mutex mutex_;
+
+    void finalize();
+};

--- a/tests/BackendConformanceTest.cpp
+++ b/tests/BackendConformanceTest.cpp
@@ -6,6 +6,9 @@
 #ifdef HAVE_ROCKSDB
 #include "backends/RocksDbBackend.h"
 #endif
+#ifdef HAVE_SQLITE
+#include "backends/SqliteBackend.h"
+#endif
 
 #include <algorithm>
 #include <atomic>
@@ -28,6 +31,12 @@ protected:
         if (GetParam() == "RocksDbBackend") {
             auto dir = makeTempDir();
             return std::make_unique<RocksDbBackend>(dir);
+        }
+#endif
+#ifdef HAVE_SQLITE
+        if (GetParam() == "SqliteBackend") {
+            auto dir = makeTempDir();
+            return std::make_unique<SqliteBackend>(dir / "test.db");
         }
 #endif
         auto dir = makeTempDir();
@@ -207,6 +216,9 @@ static auto backendValues() {
     std::vector<std::string> backends = {"MemoryBackend", "FileBackend"};
 #ifdef HAVE_ROCKSDB
     backends.push_back("RocksDbBackend");
+#endif
+#ifdef HAVE_SQLITE
+    backends.push_back("SqliteBackend");
 #endif
     return ::testing::ValuesIn(backends);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,14 @@ if(WITH_ROCKSDB)
     endif()
 endif()
 
+option(WITH_SQLITE "Build with SQLite backend" OFF)
+if(WITH_SQLITE)
+    find_package(SQLite3 REQUIRED)
+    list(APPEND BACKEND_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/backends/SqliteBackend.cpp
+    )
+endif()
+
 add_executable(backend_conformance_test
     BackendConformanceTest.cpp
     ${BACKEND_SOURCES}
@@ -58,6 +66,11 @@ if(WITH_ROCKSDB)
         target_link_libraries(backend_conformance_test PkgConfig::ROCKSDB)
     endif()
     target_compile_definitions(backend_conformance_test PRIVATE HAVE_ROCKSDB)
+endif()
+
+if(WITH_SQLITE)
+    target_link_libraries(backend_conformance_test SQLite::SQLite3)
+    target_compile_definitions(backend_conformance_test PRIVATE HAVE_SQLITE)
 endif()
 
 include(GoogleTest)


### PR DESCRIPTION
## Summary
- Adds `SqliteBackend` implementing the `KvBackend` interface using the sqlite3 C API
- Uses prepared statements for set/get/remove/clear, range-based queries for prefix listing, and `std::mutex` for thread safety
- Wired into CMake build system with `WITH_SQLITE` option and CI with a dedicated "SQLite Backend" job

## Test plan
- [x] All 12 conformance tests pass for SqliteBackend (36 total across all backends)
- [ ] CI `test-sqlite` job passes on ubuntu-latest with `libsqlite3-dev`

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)