### PR TITLE
test: add E2E logoscore test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ nix develop        # enter a dev shell with all dependencies
 
 The Nix build uses [logos-module-builder](https://github.com/logos-co/logos-module-builder) and provides Qt6, logos-cpp-sdk, and logos-liblogos automatically.
 
+## E2E Tests
+
+End-to-end tests use the `logoscore` headless test harness to validate the full plugin stack (Qt plugin loader → kv_module).
+
+```bash
+# Build first (requires Nix with flakes)
+cd ~/logos-kv-module && nix build
+
+# Run E2E tests
+bash scripts/e2e-logoscore.sh
+```
+
+The script tests `version()`, `kvSet`, `kvGet`, `kvList`, `kvRemove`, `kvClear`, and namespace isolation.
+
+> **Note:** These tests require a Nix build and are not run in CI. Run them locally before merging changes.
+
 ## Status
 
 🚧 Early design phase — see [issues](https://github.com/jimmy-claw/logos-kv-module/issues) for roadmap.

--- a/scripts/e2e-logoscore.sh
+++ b/scripts/e2e-logoscore.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  e2e-logoscore.sh — E2E tests: logoscore --call with kv_module
+# =============================================================================
+#
+#  Validates the KV module plugin stack headlessly:
+#    logoscore CLI → Qt plugin loader → kv_module
+#
+#  Tests:
+#    1. version()           — basic plugin load
+#    2. kvSet()             — store a value
+#    3. kvGet()             — retrieve and assert value
+#    4. kvSet() second key  — store second value
+#    5. kvList()            — list keys, assert both present
+#    6. kvRemove()          — remove first key
+#    7. kvGet() after remove — assert empty
+#    8. kvClear()           — clear namespace
+#    9. kvList() after clear — assert empty
+#   10. Namespace isolation — key in ns "a" not visible in ns "b"
+#
+#  Prerequisites:
+#    - Nix build:  cd ~/logos-kv-module && nix build
+#      Produces:   ~/logos-kv-module/result/{bin/logoscore,modules/}
+#
+#  Usage:
+#    bash scripts/e2e-logoscore.sh
+#
+# =============================================================================
+set -euo pipefail
+
+export PATH="$HOME/.nix-profile/bin:$PATH"
+
+# ── Paths ────────────────────────────────────────────────────────────────────
+
+LOGOSCORE="$HOME/logos-kv-module/result/bin/logoscore"
+MODULES_DIR="$HOME/logos-kv-module/result/modules"
+
+# ── Colours ──────────────────────────────────────────────────────────────────
+
+BOLD='\033[1m'; DIM='\033[2m'; RESET='\033[0m'
+GREEN='\033[0;32m'; CYAN='\033[0;36m'; YELLOW='\033[1;33m'; RED='\033[0;31m'
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+PASS=0; FAIL=0; SKIP=0
+
+pass() { echo -e "  ${GREEN}PASS${RESET}: $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${RESET}: $1 — $2"; FAIL=$((FAIL + 1)); }
+skip() { echo -e "  ${YELLOW}SKIP${RESET}: $1 — $2"; SKIP=$((SKIP + 1)); }
+banner() { echo -e "\n${CYAN}${BOLD}━━━ $1 ━━━${RESET}\n"; }
+info()   { echo -e "  ${DIM}$1${RESET}"; }
+
+cleanup_logoscore() {
+    pkill -f "logoscore.*modules-dir" 2>/dev/null || true
+    pkill -f "logos_host" 2>/dev/null || true
+    sleep 0.5
+}
+
+# Run a logoscore --call and capture output.
+# Usage: logoscore_call <load_modules> <call_expr>
+logoscore_call() {
+    local load_modules="$1"
+    local call_expr="$2"
+
+    cleanup_logoscore
+
+    local output
+    output=$(QT_QPA_PLATFORM=offscreen timeout 30 "$LOGOSCORE" \
+        --modules-dir "$MODULES_DIR" \
+        --load-modules "$load_modules" \
+        --call "$call_expr" 2>&1 || true)
+
+    cleanup_logoscore
+    echo "$output"
+}
+
+# Extract the result value after "Method call successful. Result: "
+extract_result() {
+    echo "$1" | grep "Method call successful" | sed 's/.*Result: //'
+}
+
+# ── Pre-flight ───────────────────────────────────────────────────────────────
+
+banner "Pre-flight Checks"
+
+if [[ ! -x "$LOGOSCORE" ]]; then
+    echo -e "${RED}logoscore not found at $LOGOSCORE${RESET}"
+    echo "Build with: cd ~/logos-kv-module && nix build"
+    exit 1
+fi
+pass "logoscore binary: $LOGOSCORE"
+
+if [[ ! -d "$MODULES_DIR" ]]; then
+    echo -e "${RED}modules directory not found at $MODULES_DIR${RESET}"
+    echo "Build with: cd ~/logos-kv-module && nix build"
+    exit 1
+fi
+pass "modules directory: $MODULES_DIR"
+
+# ── Test 1: version() ───────────────────────────────────────────────────────
+
+banner "Test 1: kv_module.version()"
+
+OUTPUT=$(logoscore_call "kv_module" "kv_module.version()")
+
+if echo "$OUTPUT" | grep -q "Method call successful"; then
+    RESULT=$(extract_result "$OUTPUT")
+    pass "version() = $RESULT"
+else
+    fail "version()" "unexpected output"
+    echo "$OUTPUT" | tail -5 | sed 's/^/      /'
+fi
+
+# ── Test 2: kvSet() — store a value ─────────────────────────────────────────
+
+banner "Test 2: kv_module.kvSet(\"test_ns\", \"key1\", \"hello\")"
+
+OUTPUT=$(logoscore_call "kv_module" 'kv_module.kvSet("test_ns", "key1", "hello")')
+
+if echo "$OUTPUT" | grep -q "Method call successful"; then
+    pass "kvSet(test_ns, key1, hello)"
+else
+    fail "kvSet(test_ns, key1, hello)" "unexpected output"
+    echo "$OUTPUT" | tail -5 | sed 's/^/      /'
+fi
+
+# ── Test 3: kvGet() — retrieve and assert ───────────────────────────────────
+
+banner "Test 3: kv_module.kvGet(\"test_ns\", \"key1\") — expect \"hello\""
+
+OUTPUT=$(logoscore_call "kv_module" 'kv_module.kvGet("test_ns", "key1")')
+
+if echo "$OUTPUT" | grep -q "Method call successful"; then
+    RESULT=$(extract_result "$OUTPUT")
+    if echo "$RESULT" | grep -q "hello"; then
+        pass "kvGet(test_ns, key1) = hello"
+    else
+        fail "kvGet(test_ns, key1)" "expected 'hello', got: $RESULT"
+    fi
+else
+    fail "kvGet(test_ns, key1)" "unexpected output"
+    echo "$OUTPUT" | tail -5 | sed 's/^/      /'
+fi
+
+# ── Test 4: kvSet() — store second value ────────────────────────────────────
+
+banner "Test 4: kv_module.kvSet(\"test_ns\", \"key2\", \"world\")"
+
+OUTPUT=$(logoscore_call "kv_module" 'kv_module.kvSet("test_ns", "key2", "world")')
+
+if echo "$OUTPUT" | grep -q "Method call successful"; then
+    pass "kvSet(test_ns, key2, world)"
+else
+    fail "kvSet(test_ns, key2, world)" "unexpected output"
+    echo "$OUTPUT" | tail -5 | sed 's/^/      /'
+fi
+
+# ── Test 5: kvList() — list all keys ────────────────────────────────────────
+
+banner "Test 5: kv_module.kvList(\"test_ns\", \"\") — expect key1 and key2"
+
+OUTPUT=$(logoscore_call "kv_module" 'kv_module.kvList("test_ns", "")')
+
+if echo "$OUTPUT" | grep -q "Method call successful"; then
+    RESULT=$(extract_result "$OUTPUT")
+    HAS_KEY1=false; HAS_KEY2=false
+    echo "$RESULT" | grep -q "key1" && HAS_KEY1=true
+    echo "$RESULT" | grep -q "key2" && HAS_KEY2=true
+    if $HAS_KEY1 && $HAS_KEY2; then
+        pass "kvList(test_ns) contains key1 and key2"
+    else
+        fail "kvList(test_ns)" "expected key1 and key2, got: $RESULT"
+    fi
+    info "Result: $RESULT"
+else
+    fail "kvList(test_ns)" "unexpected output"
+    echo "$OUTPUT" | tail -5 | sed 's/^/      /'
+fi
+
+# ── Test 6: kvRemove() — remove first key ───────────────────────────────────
+
+banner "Test 6: kv_module.kvRemove(\"test_ns\", \"key1\")"
+
+OUTPUT=$(logoscore_call "kv_module" 'kv_module.kvRemove("test_ns", "key1")')
+
+if echo "$OUTPUT" | grep -q "Method call successful"; then
+    pass "kvRemove(test_ns, key1)"
+else
+    fail "kvRemove(test_ns, key1)" "unexpected output"
+    echo "$OUTPUT" | tail -5 | sed 's/^/      /'
+fi
+
+# ── Test 7: kvGet() after remove — assert empty ─────────────────────────────
+
+banner "Test 7: kv_module.kvGet(\"test_ns\", \"key1\") — expect empty after remove"
+
+OUTPUT=$(logoscore_call "kv_module" 'kv_module.kvGet("test_ns", "key1")')
+
+if echo "$OUTPUT" | grep -q "Method call successful"; then
+    RESULT=$(extract_result "$OUTPUT")
+    # After remove, result should be empty (empty QByteArray)
+    if [[ -z "$RESULT" ]] || echo "$RESULT" | grep -qE '^(\s*|""|null)$'; then
+        pass "kvGet(test_ns, key1) = empty after remove"
+    else
+        fail "kvGet(test_ns, key1)" "expected empty, got: $RESULT"
+    fi
+else
+    fail "kvGet(test_ns, key1)" "unexpected output"
+    echo "$OUTPUT" | tail -5 | sed 's/^/      /'
+fi
+
+# ── Test 8: kvClear() — clear namespace ──────────────────────────────────────
+
+banner "Test 8: kv_module.kvClear(\"test_ns\")"
+
+OUTPUT=$(logoscore_call "kv_module" 'kv_module.kvClear("test_ns")')
+
+if echo "$OUTPUT" | grep -q "Method call successful"; then
+    pass "kvClear(test_ns)"
+else
+    fail "kvClear(test_ns)" "unexpected output"
+    echo "$OUTPUT" | tail -5 | sed 's/^/      /'
+fi
+
+# ── Test 9: kvList() after clear — assert empty ─────────────────────────────
+
+banner "Test 9: kv_module.kvList(\"test_ns\", \"\") — expect empty after clear"
+
+OUTPUT=$(logoscore_call "kv_module" 'kv_module.kvList("test_ns", "")')
+
+if echo "$OUTPUT" | grep -q "Method call successful"; then
+    RESULT=$(extract_result "$OUTPUT")
+    # After clear, list should return empty (no keys)
+    if [[ -z "$RESULT" ]] || echo "$RESULT" | grep -qE '^(\s*|\[\s*\]|\(\s*\))$'; then
+        pass "kvList(test_ns) = empty after clear"
+    else
+        fail "kvList(test_ns)" "expected empty, got: $RESULT"
+    fi
+else
+    fail "kvList(test_ns)" "unexpected output"
+    echo "$OUTPUT" | tail -5 | sed 's/^/      /'
+fi
+
+# ── Test 10: Namespace isolation ─────────────────────────────────────────────
+
+banner "Test 10: Namespace isolation — key in ns \"a\" not visible in ns \"b\""
+
+# Set a key in namespace "a"
+OUTPUT=$(logoscore_call "kv_module" 'kv_module.kvSet("ns_a", "secret", "hidden")')
+
+if echo "$OUTPUT" | grep -q "Method call successful"; then
+    pass "kvSet(ns_a, secret, hidden)"
+
+    # Try to read it from namespace "b" — should be empty
+    OUTPUT=$(logoscore_call "kv_module" 'kv_module.kvGet("ns_b", "secret")')
+
+    if echo "$OUTPUT" | grep -q "Method call successful"; then
+        RESULT=$(extract_result "$OUTPUT")
+        if [[ -z "$RESULT" ]] || echo "$RESULT" | grep -qE '^(\s*|""|null)$'; then
+            pass "kvGet(ns_b, secret) = empty (namespace isolation confirmed)"
+        else
+            fail "namespace isolation" "key from ns_a visible in ns_b: $RESULT"
+        fi
+    else
+        fail "kvGet(ns_b, secret)" "unexpected output"
+        echo "$OUTPUT" | tail -5 | sed 's/^/      /'
+    fi
+
+    # Cleanup: clear namespace "a"
+    logoscore_call "kv_module" 'kv_module.kvClear("ns_a")' >/dev/null 2>&1
+else
+    fail "namespace isolation setup" "could not set key in ns_a"
+    echo "$OUTPUT" | tail -5 | sed 's/^/      /'
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+banner "Results"
+
+echo -e "  ${GREEN}Passed${RESET}: $PASS"
+echo -e "  ${RED}Failed${RESET}: $FAIL"
+echo -e "  ${YELLOW}Skipped${RESET}: $SKIP"
+echo ""
+
+if [[ $FAIL -gt 0 ]]; then
+    echo -e "  ${RED}${BOLD}Some tests failed!${RESET}"
+    exit 1
+fi
+
+echo -e "  ${GREEN}${BOLD}All tests passed!${RESET}"


### PR DESCRIPTION
## Summary
- Add `scripts/e2e-logoscore.sh` — headless E2E tests using the `logoscore` harness to validate the full Qt plugin stack for `kv_module`
- Tests cover: `version()`, `kvSet`, `kvGet`, `kvList`, `kvRemove`, `kvClear`, and namespace isolation (10 test cases)
- Add "E2E Tests" section to README with build & run instructions

## Test plan
- [ ] `cd ~/logos-kv-module && nix build && bash scripts/e2e-logoscore.sh` — all 10 tests pass
- [ ] Script exits cleanly when `result/bin/logoscore` is missing (prints build instructions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)