### PR TITLE
feat: Logos Core integration (logoscore headless)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,19 +9,27 @@ find_package(Qt6 REQUIRED COMPONENTS Core Qml)
 
 set(CMAKE_AUTOMOC ON)
 
-# ── logos-cpp-sdk ─────────────────────────────────────────────────────────────
-set(LOGOS_CORE_ROOT "" CACHE PATH "Path to logos-cpp-sdk install (contains include/ and lib/)")
-if(NOT "${LOGOS_CORE_ROOT}" STREQUAL "")
+# ── Logos SDK + liblogos ──────────────────────────────────────────────────────
+set(LOGOS_CPP_SDK_ROOT "" CACHE PATH "Path to logos-cpp-sdk install")
+set(LOGOS_LIBLOGOS_ROOT "" CACHE PATH "Path to logos-liblogos install")
+
+if(NOT "${LOGOS_CPP_SDK_ROOT}" STREQUAL "" AND NOT "${LOGOS_LIBLOGOS_ROOT}" STREQUAL "")
+    set(LOGOS_CORE_AVAILABLE ON)
+
     add_library(logos_cpp_sdk INTERFACE)
     target_include_directories(logos_cpp_sdk INTERFACE
-        "${LOGOS_CORE_ROOT}/include"
-        "${LOGOS_CORE_ROOT}/include/cpp"
+        "${LOGOS_LIBLOGOS_ROOT}/include"
+        "${LOGOS_CPP_SDK_ROOT}/include"
+        "${LOGOS_CPP_SDK_ROOT}/include/cpp"
+        "${LOGOS_CPP_SDK_ROOT}/include/core"
     )
 
     add_library(logos_core SHARED IMPORTED)
     set_target_properties(logos_core PROPERTIES
-        IMPORTED_LOCATION "${LOGOS_CORE_ROOT}/lib/liblogos_core.so"
+        IMPORTED_LOCATION "${LOGOS_LIBLOGOS_ROOT}/lib/liblogos_core.so"
     )
+
+    find_library(LOGOS_SDK_LIB logos_sdk PATHS "${LOGOS_CPP_SDK_ROOT}/lib" NO_DEFAULT_PATH REQUIRED)
 endif()
 
 # ── RocksDB (optional) ────────────────────────────────────────────────────────
@@ -75,8 +83,14 @@ target_link_libraries(kv_module_plugin PRIVATE
     Qt6::Qml
 )
 
-if(NOT "${LOGOS_CORE_ROOT}" STREQUAL "")
-    target_link_libraries(kv_module_plugin PRIVATE logos_cpp_sdk logos_core)
+if(LOGOS_CORE_AVAILABLE)
+    find_package(Qt6 REQUIRED COMPONENTS RemoteObjects)
+    target_link_libraries(kv_module_plugin PRIVATE
+        Qt6::RemoteObjects
+        logos_cpp_sdk
+        logos_core
+        ${LOGOS_SDK_LIB}
+    )
     target_compile_definitions(kv_module_plugin PRIVATE LOGOS_CORE_AVAILABLE)
 endif()
 

--- a/src/kv_plugin.cpp
+++ b/src/kv_plugin.cpp
@@ -2,6 +2,12 @@
 #include "backends/MemoryBackend.h"
 #include "backends/FileBackend.h"
 
+#ifdef LOGOS_CORE_AVAILABLE
+#include <logos_api_provider.h>
+#include <logos_api_client.h>
+#endif
+
+#include <QDebug>
 #include <filesystem>
 
 KvPlugin::KvPlugin(QObject *parent)
@@ -12,11 +18,28 @@ KvPlugin::KvPlugin(QObject *parent)
 #ifdef LOGOS_CORE_AVAILABLE
 void KvPlugin::initLogos(LogosAPI* logosAPIInstance) {
     logosAPI = logosAPIInstance;
-    if (logosAPI) {
-        const QString dirProp = logosAPI->property("kvDataDir").toString();
-        if (!dirProp.isEmpty())
-            setDataDir(dirProp);
+
+    if (!logosAPI) {
+        qWarning() << "KvPlugin: initLogos called with null LogosAPI";
+        qInfo() << "KvPlugin: initialized (headless). version:" << version();
+        return;
     }
+
+    // NOTE: Do NOT call logosAPI->getProvider()->registerObject() here.
+    // In logos_host subprocess mode, the SDK wraps us in a ModuleProxy
+    // that handles registration automatically. Calling registerObject()
+    // directly causes a segfault in the QHash destructor.
+
+    m_client = logosAPI->getClient(name());
+    if (!m_client) {
+        qWarning() << "KvPlugin: failed to get client handle for" << name();
+    }
+
+    const QString dirProp = logosAPI->property("kvDataDir").toString();
+    if (!dirProp.isEmpty())
+        setDataDir(dirProp);
+
+    qInfo() << "KvPlugin: initialized. version:" << version();
 }
 #endif
 

--- a/src/kv_plugin.h
+++ b/src/kv_plugin.h
@@ -9,6 +9,8 @@
 
 #ifdef LOGOS_CORE_AVAILABLE
 #include <interface.h>
+class LogosAPIClient;
+
 class KvPlugin final : public QObject, public PluginInterface, public IKvModule {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID IKvModule_iid FILE "metadata.json")
@@ -24,11 +26,14 @@ public:
     explicit KvPlugin(QObject *parent = nullptr);
     ~KvPlugin() override = default;
 
+    // ── PluginInterface ─────────────────────────────────────────────────────
+#ifdef LOGOS_CORE_AVAILABLE
+    [[nodiscard]] QString name() const override { return QStringLiteral("kv_module"); }
+    Q_INVOKABLE QString version() const override { return QStringLiteral("0.1.0"); }
+    Q_INVOKABLE void initLogos(LogosAPI* logosAPIInstance);
+#else
     [[nodiscard]] QString name() const { return QStringLiteral("kv_module"); }
     Q_INVOKABLE QString version() const { return QStringLiteral("0.1.0"); }
-
-#ifdef LOGOS_CORE_AVAILABLE
-    Q_INVOKABLE void initLogos(LogosAPI* logosAPIInstance);
 #endif
 
     // IKvModule operations
@@ -52,6 +57,6 @@ private:
     bool use_file_backend_ = false;
 
 #ifdef LOGOS_CORE_AVAILABLE
-    LogosAPI* logosAPI = nullptr;
+    LogosAPIClient* m_client = nullptr;
 #endif
 };


### PR DESCRIPTION
Implements PluginInterface + initLogos() so kv_module runs inside logos_host via logoscore. Follows lez-multisig-module pattern. Plugin name(), version(), kvSet/kvGet/kvRemove/kvList/kvClear all wired up.