### PR TITLE
fix: QString signatures for kvSet/kvGet (logoscore compat)

### DIFF
--- a/src/i_kv_module.h
+++ b/src/i_kv_module.h
@@ -25,6 +25,7 @@ public:
     virtual QString kvGet(const QString& ns, const QString& key) = 0;
     virtual void kvRemove(const QString& ns, const QString& key) = 0;
     virtual QString kvList(const QString& ns, const QString& prefix) = 0;
+    virtual QString kvListAll(const QString& ns) = 0;
     virtual void kvClear(const QString& ns) = 0;
 };
 

--- a/src/kv_plugin.cpp
+++ b/src/kv_plugin.cpp
@@ -103,6 +103,10 @@ QString KvPlugin::kvList(const QString& ns, const QString& prefix) {
     return result;
 }
 
+QString KvPlugin::kvListAll(const QString& ns) {
+    return kvList(ns, QString());
+}
+
 void KvPlugin::kvClear(const QString& ns) {
     backendForNamespace(ns.toStdString()).clear();
     emit kvChanged(ns, QString());

--- a/src/kv_plugin.h
+++ b/src/kv_plugin.h
@@ -41,6 +41,7 @@ public:
     Q_INVOKABLE QString kvGet(const QString& ns, const QString& key) override;
     Q_INVOKABLE void kvRemove(const QString& ns, const QString& key) override;
     Q_INVOKABLE QString kvList(const QString& ns, const QString& prefix) override;
+    Q_INVOKABLE QString kvListAll(const QString& ns) override;
     Q_INVOKABLE void kvClear(const QString& ns) override;
 
     void setDataDir(const QString &path);


### PR DESCRIPTION
logoscore passes QString args; QByteArray caused invalid result. Also fixes kvGet return type.