### PR TITLE
ci: weekly auto-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,25 +37,59 @@ jobs:
         if: steps.check_commits.outputs.commits != '0'
         run: |
           TAG=${{ steps.latest_tag.outputs.tag }}
-          # Strip leading 'v', split semver
           VERSION=${TAG#v}
           MAJOR=$(echo $VERSION | cut -d. -f1)
           MINOR=$(echo $VERSION | cut -d. -f2)
           PATCH=$(echo $VERSION | cut -d. -f3)
-          NEW_PATCH=$((PATCH + 1))
-          NEW_TAG="v${MAJOR}.${MINOR}.${NEW_PATCH}"
+          NEW_TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
           echo "tag=$NEW_TAG" >> $GITHUB_OUTPUT
           echo "New tag: $NEW_TAG"
 
-      - name: Generate changelog
+      - name: Generate changelog entry
         id: changelog
         if: steps.check_commits.outputs.commits != '0'
         run: |
           TAG=${{ steps.latest_tag.outputs.tag }}
-          LOG=$(git log ${TAG}..HEAD --oneline --no-merges | head -20)
-          echo "log<<EOF" >> $GITHUB_OUTPUT
-          echo "$LOG" >> $GITHUB_OUTPUT
+          NEW_TAG=${{ steps.new_version.outputs.tag }}
+          DATE=$(date +%Y-%m-%d)
+          LOG=$(git log ${TAG}..HEAD --oneline --no-merges | head -30 | sed 's/^/- /')
+          
+          ENTRY="## [$NEW_TAG] - $DATE\n\n$LOG\n"
+          echo "entry<<EOF" >> $GITHUB_OUTPUT
+          printf "$ENTRY" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+          
+          # Also save for CHANGELOG update
+          printf "$ENTRY" > /tmp/new_entry.md
+
+      - name: Update CHANGELOG.md
+        if: steps.check_commits.outputs.commits != '0'
+        run: |
+          NEW_TAG=${{ steps.new_version.outputs.tag }}
+          DATE=$(date +%Y-%m-%d)
+
+          if [ ! -f CHANGELOG.md ]; then
+            echo "# Changelog" > CHANGELOG.md
+            echo "" >> CHANGELOG.md
+            echo "All notable changes to logos-kv-module are documented here." >> CHANGELOG.md
+            echo "" >> CHANGELOG.md
+          fi
+
+          # Insert new entry after the header
+          HEAD=$(head -4 CHANGELOG.md)
+          TAIL=$(tail -n +5 CHANGELOG.md)
+          {
+            echo "$HEAD"
+            echo ""
+            cat /tmp/new_entry.md
+            echo "$TAIL"
+          } > CHANGELOG.tmp && mv CHANGELOG.tmp CHANGELOG.md
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "chore: update CHANGELOG for $NEW_TAG"
+          git push
 
       - name: Create release
         if: steps.check_commits.outputs.commits != '0'
@@ -65,7 +99,7 @@ jobs:
           NEW_TAG=${{ steps.new_version.outputs.tag }}
           git tag $NEW_TAG
           git push origin $NEW_TAG
-          gh release create $NEW_TAG             --title "$NEW_TAG"             --notes "${{ steps.changelog.outputs.log }}"             --latest
+          gh release create $NEW_TAG             --title "$NEW_TAG"             --notes-file /tmp/new_entry.md             --latest
 
       - name: No release needed
         if: steps.check_commits.outputs.commits == '0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to logos-kv-module are documented here.
+
+## [v0.1.0] - 2026-03-09
+
+- feat: initial release — Memory, File, RocksDB, SQLite backends
+- feat: Qt plugin interface (IKvModule) with Logos Core integration
+- feat: set/get/list/listAll/remove/clear methods via QtRO
+- ci: conformance tests, Qt plugin build, RocksDB, SQLite, E2E Nix jobs
+- docs: README, logoscore testing gotchas PR to logos-module-builder


### PR DESCRIPTION
Runs every Monday 9am UTC. If there are commits since the last tag, bumps patch version and creates a GitHub release with changelog. Skips if nothing new.