### PR TITLE
feat: scan and searchValues API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,29 @@ QString  listAll(QString ns);                 // list with empty prefix
 void     clear(QString ns);
 QString  version();
 
+// Search
+QString  scan(QString ns, QString pattern);           // returns JSON array of matching keys
+QString  searchValues(QString ns, QString substring); // returns JSON array of {key, value}
+
 // Optional per-namespace encryption (AES-256-GCM)
 void     setEncryptionKey(QString ns, QString keyHex);
 ```
 
 Namespacing ensures modules can't read each other's data.
+
+### Search
+
+`scan(ns, pattern)` finds keys containing `pattern` as a substring. Empty pattern returns all keys.
+
+`searchValues(ns, substring)` finds entries where the value contains `substring` (case-insensitive). Returns a JSON array of `{"key": "...", "value": "..."}` objects.
+
+```cpp
+kv_module.scan("myapp", "user");
+// ["user:1", "user:2", "admin_user"]
+
+kv_module.searchValues("myapp", "meeting");
+// [{"key":"event:1","value":"Team Meeting at 10am"}, ...]
+```
 
 ### Encryption
 

--- a/src/backends/FileBackend.cpp
+++ b/src/backends/FileBackend.cpp
@@ -1,5 +1,7 @@
 #include "FileBackend.h"
 
+#include <algorithm>
+#include <cctype>
 #include <fstream>
 #include <sstream>
 #include <unordered_map>
@@ -111,6 +113,17 @@ std::string toJson(const std::unordered_map<std::string, std::string> &map) {
     return out.str();
 }
 
+bool containsCaseInsensitive(const std::string &haystack, const std::string &needle) {
+    if (needle.empty()) return true;
+    auto it = std::search(haystack.begin(), haystack.end(),
+                          needle.begin(), needle.end(),
+                          [](char a, char b) {
+                              return std::tolower(static_cast<unsigned char>(a)) ==
+                                     std::tolower(static_cast<unsigned char>(b));
+                          });
+    return it != haystack.end();
+}
+
 } // anonymous namespace
 
 FileBackend::FileBackend(std::filesystem::path data_dir)
@@ -182,4 +195,27 @@ std::vector<std::string> FileBackend::list(const std::string &prefix) {
 void FileBackend::clear() {
     std::lock_guard lock(mutex_);
     save({});
+}
+
+std::vector<std::string> FileBackend::scan(const std::string &pattern) {
+    std::lock_guard lock(mutex_);
+    auto data = load();
+    std::vector<std::string> result;
+    for (const auto &[k, v] : data) {
+        if (pattern.empty() || k.find(pattern) != std::string::npos)
+            result.push_back(k);
+    }
+    return result;
+}
+
+std::vector<std::pair<std::string, std::string>>
+FileBackend::searchValues(const std::string &substring) {
+    std::lock_guard lock(mutex_);
+    auto data = load();
+    std::vector<std::pair<std::string, std::string>> result;
+    for (const auto &[k, v] : data) {
+        if (containsCaseInsensitive(v, substring))
+            result.emplace_back(k, v);
+    }
+    return result;
 }

--- a/src/backends/FileBackend.h
+++ b/src/backends/FileBackend.h
@@ -16,6 +16,10 @@ public:
     std::vector<std::string> list(const std::string &prefix) override;
     void clear() override;
 
+    std::vector<std::string> scan(const std::string &pattern) override;
+    std::vector<std::pair<std::string, std::string>>
+        searchValues(const std::string &substring) override;
+
 private:
     std::filesystem::path data_dir_;
     std::mutex mutex_;

--- a/src/backends/KvBackend.h
+++ b/src/backends/KvBackend.h
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 class KvBackend {
@@ -13,4 +14,8 @@ public:
     virtual void remove(const std::string &key) = 0;
     virtual std::vector<std::string> list(const std::string &prefix) = 0;
     virtual void clear() = 0;
+
+    virtual std::vector<std::string> scan(const std::string &pattern) = 0;
+    virtual std::vector<std::pair<std::string, std::string>>
+        searchValues(const std::string &substring) = 0;
 };

--- a/src/backends/MemoryBackend.cpp
+++ b/src/backends/MemoryBackend.cpp
@@ -1,6 +1,21 @@
 #include "MemoryBackend.h"
 
+#include <algorithm>
+#include <cctype>
 #include <mutex>
+
+namespace {
+bool containsCaseInsensitive(const std::string &haystack, const std::string &needle) {
+    if (needle.empty()) return true;
+    auto it = std::search(haystack.begin(), haystack.end(),
+                          needle.begin(), needle.end(),
+                          [](char a, char b) {
+                              return std::tolower(static_cast<unsigned char>(a)) ==
+                                     std::tolower(static_cast<unsigned char>(b));
+                          });
+    return it != haystack.end();
+}
+} // namespace
 
 void MemoryBackend::set(const std::string &key, const std::string &value) {
     std::unique_lock lock(mutex_);
@@ -33,4 +48,25 @@ std::vector<std::string> MemoryBackend::list(const std::string &prefix) {
 void MemoryBackend::clear() {
     std::unique_lock lock(mutex_);
     store_.clear();
+}
+
+std::vector<std::string> MemoryBackend::scan(const std::string &pattern) {
+    std::shared_lock lock(mutex_);
+    std::vector<std::string> result;
+    for (const auto &[k, v] : store_) {
+        if (pattern.empty() || k.find(pattern) != std::string::npos)
+            result.push_back(k);
+    }
+    return result;
+}
+
+std::vector<std::pair<std::string, std::string>>
+MemoryBackend::searchValues(const std::string &substring) {
+    std::shared_lock lock(mutex_);
+    std::vector<std::pair<std::string, std::string>> result;
+    for (const auto &[k, v] : store_) {
+        if (containsCaseInsensitive(v, substring))
+            result.emplace_back(k, v);
+    }
+    return result;
 }

--- a/src/backends/MemoryBackend.h
+++ b/src/backends/MemoryBackend.h
@@ -13,6 +13,10 @@ public:
     std::vector<std::string> list(const std::string &prefix) override;
     void clear() override;
 
+    std::vector<std::string> scan(const std::string &pattern) override;
+    std::vector<std::pair<std::string, std::string>>
+        searchValues(const std::string &substring) override;
+
 private:
     std::unordered_map<std::string, std::string> store_;
     mutable std::shared_mutex mutex_;

--- a/src/backends/RocksDbBackend.cpp
+++ b/src/backends/RocksDbBackend.cpp
@@ -1,9 +1,24 @@
 #include "RocksDbBackend.h"
 
+#include <algorithm>
+#include <cctype>
 #include <rocksdb/db.h>
 #include <rocksdb/iterator.h>
 #include <rocksdb/write_batch.h>
 #include <stdexcept>
+
+namespace {
+bool containsCaseInsensitive(const std::string &haystack, const std::string &needle) {
+    if (needle.empty()) return true;
+    auto it = std::search(haystack.begin(), haystack.end(),
+                          needle.begin(), needle.end(),
+                          [](char a, char b) {
+                              return std::tolower(static_cast<unsigned char>(a)) ==
+                                     std::tolower(static_cast<unsigned char>(b));
+                          });
+    return it != haystack.end();
+}
+} // namespace
 
 RocksDbBackend::RocksDbBackend(std::filesystem::path db_path)
     : db_path_(std::move(db_path)) {
@@ -82,4 +97,30 @@ void RocksDbBackend::clear() {
     if (!status.ok()) {
         throw std::runtime_error("RocksDB clear failed: " + status.ToString());
     }
+}
+
+std::vector<std::string> RocksDbBackend::scan(const std::string &pattern) {
+    std::vector<std::string> result;
+    std::unique_ptr<rocksdb::Iterator> it(
+        db_->NewIterator(rocksdb::ReadOptions()));
+    for (it->SeekToFirst(); it->Valid(); it->Next()) {
+        std::string key(it->key().data(), it->key().size());
+        if (pattern.empty() || key.find(pattern) != std::string::npos)
+            result.push_back(std::move(key));
+    }
+    return result;
+}
+
+std::vector<std::pair<std::string, std::string>>
+RocksDbBackend::searchValues(const std::string &substring) {
+    std::vector<std::pair<std::string, std::string>> result;
+    std::unique_ptr<rocksdb::Iterator> it(
+        db_->NewIterator(rocksdb::ReadOptions()));
+    for (it->SeekToFirst(); it->Valid(); it->Next()) {
+        std::string val(it->value().data(), it->value().size());
+        if (containsCaseInsensitive(val, substring))
+            result.emplace_back(
+                std::string(it->key().data(), it->key().size()), std::move(val));
+    }
+    return result;
 }

--- a/src/backends/RocksDbBackend.h
+++ b/src/backends/RocksDbBackend.h
@@ -21,6 +21,10 @@ public:
     std::vector<std::string> list(const std::string &prefix) override;
     void clear() override;
 
+    std::vector<std::string> scan(const std::string &pattern) override;
+    std::vector<std::pair<std::string, std::string>>
+        searchValues(const std::string &substring) override;
+
 private:
     std::filesystem::path db_path_;
     rocksdb::DB *db_ = nullptr;

--- a/src/backends/SqliteBackend.cpp
+++ b/src/backends/SqliteBackend.cpp
@@ -197,3 +197,96 @@ void SqliteBackend::clear() {
                                  sqlite3_errmsg(db_));
     }
 }
+
+std::vector<std::string> SqliteBackend::scan(const std::string &pattern) {
+    std::lock_guard lock(mutex_);
+    std::vector<std::string> result;
+
+    sqlite3_stmt *stmt = nullptr;
+    std::string like = "%" + pattern + "%";
+    int rc;
+
+    if (pattern.empty()) {
+        rc = sqlite3_prepare_v2(db_, "SELECT key FROM kv ORDER BY key", -1,
+                                &stmt, nullptr);
+    } else {
+        rc = sqlite3_prepare_v2(db_,
+            "SELECT key FROM kv WHERE key LIKE ? ORDER BY key",
+            -1, &stmt, nullptr);
+        if (rc == SQLITE_OK) {
+            sqlite3_bind_text(stmt, 1, like.data(),
+                              static_cast<int>(like.size()), SQLITE_STATIC);
+        }
+    }
+
+    if (rc != SQLITE_OK) {
+        throw std::runtime_error(std::string("SQLite scan prepare failed: ") +
+                                 sqlite3_errmsg(db_));
+    }
+
+    while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+        const char *key =
+            reinterpret_cast<const char *>(sqlite3_column_text(stmt, 0));
+        int len = sqlite3_column_bytes(stmt, 0);
+        result.emplace_back(key, static_cast<size_t>(len));
+    }
+    sqlite3_finalize(stmt);
+
+    if (rc != SQLITE_DONE) {
+        throw std::runtime_error(std::string("SQLite scan failed: ") +
+                                 sqlite3_errmsg(db_));
+    }
+
+    return result;
+}
+
+std::vector<std::pair<std::string, std::string>>
+SqliteBackend::searchValues(const std::string &substring) {
+    std::lock_guard lock(mutex_);
+    std::vector<std::pair<std::string, std::string>> result;
+
+    sqlite3_stmt *stmt = nullptr;
+    std::string like = "%" + substring + "%";
+    int rc;
+
+    if (substring.empty()) {
+        rc = sqlite3_prepare_v2(db_,
+            "SELECT key, value FROM kv ORDER BY key",
+            -1, &stmt, nullptr);
+    } else {
+        rc = sqlite3_prepare_v2(db_,
+            "SELECT key, value FROM kv WHERE value LIKE ? ORDER BY key",
+            -1, &stmt, nullptr);
+        if (rc == SQLITE_OK) {
+            sqlite3_bind_text(stmt, 1, like.data(),
+                              static_cast<int>(like.size()), SQLITE_STATIC);
+        }
+    }
+
+    if (rc != SQLITE_OK) {
+        throw std::runtime_error(
+            std::string("SQLite searchValues prepare failed: ") +
+            sqlite3_errmsg(db_));
+    }
+
+    while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+        const char *key =
+            reinterpret_cast<const char *>(sqlite3_column_text(stmt, 0));
+        int klen = sqlite3_column_bytes(stmt, 0);
+        const void *blob = sqlite3_column_blob(stmt, 1);
+        int vlen = sqlite3_column_bytes(stmt, 1);
+        result.emplace_back(
+            std::string(key, static_cast<size_t>(klen)),
+            std::string(static_cast<const char *>(blob),
+                        static_cast<size_t>(vlen)));
+    }
+    sqlite3_finalize(stmt);
+
+    if (rc != SQLITE_DONE) {
+        throw std::runtime_error(
+            std::string("SQLite searchValues failed: ") +
+            sqlite3_errmsg(db_));
+    }
+
+    return result;
+}

--- a/src/backends/SqliteBackend.h
+++ b/src/backends/SqliteBackend.h
@@ -19,6 +19,10 @@ public:
     std::vector<std::string> list(const std::string &prefix) override;
     void clear() override;
 
+    std::vector<std::string> scan(const std::string &pattern) override;
+    std::vector<std::pair<std::string, std::string>>
+        searchValues(const std::string &substring) override;
+
 private:
     std::filesystem::path db_path_;
     sqlite3 *db_ = nullptr;

--- a/src/i_kv_module.h
+++ b/src/i_kv_module.h
@@ -27,6 +27,11 @@ public:
     virtual QString list(const QString& ns, const QString& prefix) = 0;
     virtual QString listAll(const QString& ns) = 0;
     virtual void clear(const QString& ns) = 0;
+
+    // ── Search Operations ───────────────────────────────────────────────────
+
+    virtual QString scan(const QString& ns, const QString& pattern) = 0;
+    virtual QString searchValues(const QString& ns, const QString& substring) = 0;
 };
 
 #define IKvModule_iid "com.logos.module.IKvModule"

--- a/src/kv_plugin.cpp
+++ b/src/kv_plugin.cpp
@@ -212,3 +212,53 @@ void KvPlugin::clear(const QString& ns) {
     backendForNamespace(ns.toStdString()).clear();
     emit changed(ns, QString());
 }
+
+QString KvPlugin::scan(const QString& ns, const QString& pattern) {
+    auto keys = backendForNamespace(ns.toStdString()).scan(pattern.toStdString());
+    QString result = QStringLiteral("[");
+    bool first = true;
+    for (const auto &k : keys) {
+        if (!first) result += ',';
+        result += '"' + QString::fromStdString(k) + '"';
+        first = false;
+    }
+    result += ']';
+    return result;
+}
+
+QString KvPlugin::searchValues(const QString& ns, const QString& substring) {
+    auto encIt = encryption_keys_.find(ns);
+    bool encrypted = (encIt != encryption_keys_.end());
+
+    // For encrypted namespaces, get all entries and decrypt before matching
+    auto entries = encrypted
+        ? backendForNamespace(ns.toStdString()).searchValues(std::string())
+        : backendForNamespace(ns.toStdString()).searchValues(substring.toStdString());
+
+    QString result = QStringLiteral("[");
+    bool first = true;
+    for (const auto &[k, v] : entries) {
+        QString value;
+        if (encrypted) {
+            QByteArray decrypted = decrypt(encIt.value(), QByteArray::fromStdString(v));
+            if (decrypted.isEmpty())
+                continue;
+            value = QString::fromUtf8(decrypted);
+            if (!value.contains(substring, Qt::CaseInsensitive))
+                continue;
+        } else {
+            value = QString::fromStdString(v);
+        }
+        if (!first) result += ',';
+        // Escape quotes in key and value for JSON safety
+        QString escapedKey = QString::fromStdString(k);
+        escapedKey.replace('\\', QStringLiteral("\\\\")).replace('"', QStringLiteral("\\\""));
+        value.replace('\\', QStringLiteral("\\\\")).replace('"', QStringLiteral("\\\""));
+        result += QStringLiteral("{\"key\":\"") + escapedKey
+                + QStringLiteral("\",\"value\":\"") + value
+                + QStringLiteral("\"}");
+        first = false;
+    }
+    result += ']';
+    return result;
+}

--- a/src/kv_plugin.h
+++ b/src/kv_plugin.h
@@ -47,6 +47,10 @@ public:
     Q_INVOKABLE QString listAll(const QString& ns) override;
     Q_INVOKABLE void clear(const QString& ns) override;
 
+    // Search operations
+    Q_INVOKABLE QString scan(const QString& ns, const QString& pattern) override;
+    Q_INVOKABLE QString searchValues(const QString& ns, const QString& substring) override;
+
     void setDataDir(const QString &path);
 
     // ── Encryption ──────────────────────────────────────────────────────────

--- a/tests/BackendConformanceTest.cpp
+++ b/tests/BackendConformanceTest.cpp
@@ -217,6 +217,100 @@ TEST_P(BackendConformanceTest, ConcurrentWrites) {
     }
 }
 
+// --- Scan operations ---
+
+TEST_P(BackendConformanceTest, ScanEmptyPatternReturnsAllKeys) {
+    backend->set("user:1", "alice");
+    backend->set("user:2", "bob");
+    backend->set("item:1", "widget");
+
+    auto result = backend->scan("");
+    EXPECT_EQ(result.size(), 3u);
+}
+
+TEST_P(BackendConformanceTest, ScanFiltersBySubstring) {
+    backend->set("user:1", "alice");
+    backend->set("user:2", "bob");
+    backend->set("item:1", "widget");
+
+    auto result = backend->scan("user");
+    std::sort(result.begin(), result.end());
+
+    ASSERT_EQ(result.size(), 2u);
+    EXPECT_EQ(result[0], "user:1");
+    EXPECT_EQ(result[1], "user:2");
+}
+
+TEST_P(BackendConformanceTest, ScanNoMatchReturnsEmpty) {
+    backend->set("user:1", "alice");
+    backend->set("item:1", "widget");
+
+    auto result = backend->scan("zzz");
+    EXPECT_TRUE(result.empty());
+}
+
+TEST_P(BackendConformanceTest, ScanMatchesSubstringAnywhere) {
+    backend->set("my_user_key", "val1");
+    backend->set("admin_user", "val2");
+    backend->set("item:1", "val3");
+
+    auto result = backend->scan("user");
+    std::sort(result.begin(), result.end());
+
+    ASSERT_EQ(result.size(), 2u);
+    EXPECT_EQ(result[0], "admin_user");
+    EXPECT_EQ(result[1], "my_user_key");
+}
+
+// --- SearchValues operations ---
+
+TEST_P(BackendConformanceTest, SearchValuesFindsSubstringCaseInsensitive) {
+    backend->set("k1", "Hello World");
+    backend->set("k2", "goodbye");
+    backend->set("k3", "HELLO there");
+
+    auto result = backend->searchValues("hello");
+    std::sort(result.begin(), result.end());
+
+    ASSERT_EQ(result.size(), 2u);
+    EXPECT_EQ(result[0].first, "k1");
+    EXPECT_EQ(result[0].second, "Hello World");
+    EXPECT_EQ(result[1].first, "k3");
+    EXPECT_EQ(result[1].second, "HELLO there");
+}
+
+TEST_P(BackendConformanceTest, SearchValuesNoMatchReturnsEmpty) {
+    backend->set("k1", "Hello World");
+    backend->set("k2", "goodbye");
+
+    auto result = backend->searchValues("zzz");
+    EXPECT_TRUE(result.empty());
+}
+
+TEST_P(BackendConformanceTest, SearchValuesMultipleMatches) {
+    backend->set("event:1", "Team Meeting at 10am");
+    backend->set("event:2", "Lunch meeting with Bob");
+    backend->set("event:3", "Dentist appointment");
+
+    auto result = backend->searchValues("meeting");
+    ASSERT_EQ(result.size(), 2u);
+
+    // Verify both matching entries are present
+    std::sort(result.begin(), result.end());
+    EXPECT_EQ(result[0].first, "event:1");
+    EXPECT_EQ(result[0].second, "Team Meeting at 10am");
+    EXPECT_EQ(result[1].first, "event:2");
+    EXPECT_EQ(result[1].second, "Lunch meeting with Bob");
+}
+
+TEST_P(BackendConformanceTest, SearchValuesEmptySubstringReturnsAll) {
+    backend->set("k1", "value1");
+    backend->set("k2", "value2");
+
+    auto result = backend->searchValues("");
+    EXPECT_EQ(result.size(), 2u);
+}
+
 static auto backendValues() {
     std::vector<std::string> backends = {"MemoryBackend", "FileBackend"};
 #ifdef HAVE_ROCKSDB


### PR DESCRIPTION
Closes #23.

## Summary
- Adds `scan(ns, pattern)` — find keys by substring match, returns JSON array of matching keys
- Adds `searchValues(ns, substring)` — find entries where value contains substring (case-insensitive), returns JSON array of `{key, value}` objects
- Implemented across all backends (Memory, File, RocksDB, SQLite)
- SQLite backend uses `LIKE` queries for efficient search
- Encrypted namespaces are supported: values are decrypted before matching in `searchValues`

## Test plan
- [x] `scan`: empty pattern returns all keys
- [x] `scan`: filters by substring match
- [x] `scan`: matches substring anywhere in key (not just prefix)
- [x] `scan`: no match returns empty array
- [x] `searchValues`: case-insensitive substring match
- [x] `searchValues`: no match returns empty array
- [x] `searchValues`: multiple matches returned correctly
- [x] `searchValues`: empty substring returns all entries
- [x] All existing tests pass (40/40)

🤖 Generated with [Claude Code](https://claude.com/claude-code)