### PR TITLE
fix: make setDataDir Q_INVOKABLE so it can be called via ModuleProxy

### DIFF
--- a/src/kv_plugin.h
+++ b/src/kv_plugin.h
@@ -47,7 +47,7 @@ public:
     Q_INVOKABLE QString listAll(const QString& ns) override;
     Q_INVOKABLE void clear(const QString& ns) override;
 
-    void setDataDir(const QString &path);
+    Q_INVOKABLE void setDataDir(const QString &path);
 
     // ── Encryption ──────────────────────────────────────────────────────────
     Q_INVOKABLE void setEncryptionKey(const QString& ns, const QString& keyHex);


### PR DESCRIPTION
## Problem
`setDataDir()` exists on `KvPlugin` to switch to the `FileBackend` for persistent storage, but it was missing `Q_INVOKABLE`. This means it couldn't be called remotely via `ModuleProxy::invokeRemoteMethod()` from other modules.

## Fix
Added `Q_INVOKABLE` to `setDataDir(const QString &path)`.

## Impact
Allows modules (e.g. scala calendar) to call `setDataDir` via logos-app's QtRO mechanism to enable file-based persistence instead of the default in-memory backend.